### PR TITLE
S.zero cannot unpack mpf objects.

### DIFF
--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -1186,7 +1186,7 @@ def evalf_sum(expr, prec, options):
     if len(limits) != 1 or len(limits[0]) != 3:
         raise NotImplementedError
     if func is S.Zero:
-        return mpf(0), None, None, None
+        return None, None, None, None
     prec2 = prec + 10
     try:
         n, a, b = limits[0]


### PR DESCRIPTION

<!-- Fixes #11151 -->


#### Brief description of what is fixed or changed
Since Sum(0,(a,1,2)) gives TypeError while S.Zero returns a value 0 . It shows that Sum cannot unpack untraceable mpf objects.Hence,I changed it to None so that it returns 0.

<!-- BEGIN RELEASE NOTES -->
*core
 *changed mpf(0) to None in evalf_sum in evalf.py
<!-- END RELEASE NOTES -->
